### PR TITLE
루비 버전 매니저의 링크를 유효한 주소로 변경하라

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://johngrib.github.io/wiki/my-wiki/
 
 ```bash
 # See also https://rvm.io/rvm/install
-$ gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+$ gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 $ curl -sSL https://get.rvm.io | bash
 $ rvm install 2.7.4
 $ rvm use 2.7.4


### PR DESCRIPTION
루비 설치시 기존 keyserver 주소가 작동하지 않아 유효한 링크로 변경합니다.
See also: https://github.com/rvm/rvm/issues/4215#issuecomment-1029080844